### PR TITLE
Feat/hide toggle eye icon

### DIFF
--- a/components/atoms/input/index.tsx
+++ b/components/atoms/input/index.tsx
@@ -11,6 +11,7 @@ export const Input = ({
     register,
     handleHideIcon,
     placeholder,
+    inputHasValue,
     hasHideIcon = false,
     isHidden
 }: InputProps) => {
@@ -27,7 +28,7 @@ export const Input = ({
                 disabled={disabled}
                 {...register(name, { required })}
             />
-            {hasHideIcon && (
+            {(hasHideIcon || inputHasValue) && (
                 <span
                     onClick={handleHideIcon}
                     role='button'

--- a/components/molecules/formLabel/index.tsx
+++ b/components/molecules/formLabel/index.tsx
@@ -11,6 +11,7 @@ export interface FormLabelProps extends InputProps {
     hasHideIcon?: boolean;
     isHidden?: boolean;
     errorMessage?: string | undefined;
+    inputHasValue?: boolean;
 }
 
 export const FormLabel = ({ 
@@ -24,8 +25,10 @@ export const FormLabel = ({
     hasHideIcon, 
     labelName,
     errorMessage,
-    disabled
+    disabled,
+    inputHasValue
 }: FormLabelProps) => {
+
     return (
         <section className='py-2'>
             <Label htmlFor={name} labelName={labelName}
@@ -39,6 +42,7 @@ export const FormLabel = ({
                 isHidden={isHidden}
                 name={name}
                 register={register}
+                inputHasValue={inputHasValue}
                 required={required}
                 disabled={disabled}
             />

--- a/components/organisms/header/header.tsx
+++ b/components/organisms/header/header.tsx
@@ -25,7 +25,6 @@ export const Header = () => {
     };
 
     const handleLogout = () => {
-        console.log('logged out')
         setNav(!nav);
         router.push('/login')
     };

--- a/components/organisms/header/header.tsx
+++ b/components/organisms/header/header.tsx
@@ -14,7 +14,7 @@ import { UserHead } from './userHead';
 
 export const Header = () => {
     const [nav, setNav] = useState(false);
-    const [loggedIn, setLoggedIn] = useState(true);
+    const [loggedIn, setLoggedIn] = useState(false);
     const p = useProfileStore();
     const { profile } = p;
     const router = useRouter();

--- a/components/organisms/login/index.tsx
+++ b/components/organisms/login/index.tsx
@@ -15,9 +15,10 @@ const loginSchema = z.object({
 
 export const LoginForm = () => {
     const [hidden, setHidden] = React.useState(true);
-    const { register, handleSubmit, formState: { errors } } = useForm({
+    const { register, handleSubmit, watch, formState: { errors } } = useForm({
         resolver: zodResolver(loginSchema)
     });
+    const showIcon = watch('password');
 
     const handleLogin = async (data: any) => {
         const { username, password } = data;
@@ -57,12 +58,13 @@ export const LoginForm = () => {
                         placeholder='Enter password'
                         labelName='Password'
                         name='password'
-                        hasHideIcon={true}
+                        hasHideIcon={false}
                         handleHideIcon={() => setHidden(!hidden)}
                         isHidden={hidden}
                         register={register}
                         required={true}
                         errorMessage={errors?.password && errors?.password?.message?.toString()}
+                        inputHasValue={showIcon ? true : false}
                     />
                     <Button
                         handleClick={handleLogin} 

--- a/components/organisms/register/personalDetails.tsx
+++ b/components/organisms/register/personalDetails.tsx
@@ -5,9 +5,10 @@ import { FormLabel } from '../../molecules/formLabel';
 interface IProps {
     register: Function;
     component: React.ReactNode;
+    watch: Function;
 }
 
-export const PersonalDetails = ({ component, register }: IProps) => {
+export const PersonalDetails = ({ component, register, watch }: IProps) => {
     const [hidden, setHidden] = useState(true);
 
     return (
@@ -53,8 +54,9 @@ export const PersonalDetails = ({ component, register }: IProps) => {
                     register={register}
                     required={true}
                     handleHideIcon={() => setHidden(!hidden)}
-                    hasHideIcon={true}
+                    hasHideIcon={false}
                     isHidden={hidden}
+                    inputHasValue={watch ? true : false}
                 />
                 <section className='mt-4 block'>
                     {component}

--- a/components/templates/register/index.tsx
+++ b/components/templates/register/index.tsx
@@ -9,7 +9,8 @@ export const Registration = () => {
     const [currentPage, setCurrentPage] = useState(0);
     const [firstPage, setFirstPage] = useState<boolean | null>(true);
     const [lastPage, setLastPage] = useState(false);
-    const { register, handleSubmit } = useForm();
+    const { register, watch, handleSubmit } = useForm();
+    const showIcon = watch('password');
  
     const handleNext = () => {
         if (currentPage !== (forms.length - 1)) {
@@ -67,6 +68,7 @@ export const Registration = () => {
             key={0} 
             register={register} 
             component={navButton} 
+            watch={watch('password')}
         />, 
         <ProjectsPortfolio 
             key={1}

--- a/types.ts
+++ b/types.ts
@@ -7,6 +7,7 @@ export interface InputProps {
     isHidden?: boolean;
     handleHideIcon?: React.MouseEventHandler<HTMLSpanElement>;
     required: boolean;
+    inputHasValue?: boolean | undefined;
     register: Function;
     disabled?: boolean;
 }


### PR DESCRIPTION
Fixed toggle eye icon on the password input when user types password.

The eye icon was always displaying even if the password was not yet typed -that is - empty. The proposed fix was to hide the toggle icon until at least a single character is typed in the input.