### PR TITLE
refactor: changed route for milestones

### DIFF
--- a/app/offers/[offerId]/activity/add-milestones/page.tsx
+++ b/app/offers/[offerId]/activity/add-milestones/page.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import AddMilestones from '../../../../../components/templates/projects/projectId/activity/add-milestones';
+
+export default function AddMilestonesPage() {
+    return (
+        <section className='p-3 md:container'>
+            <AddMilestones />
+        </section>
+    );
+}

--- a/components/molecules/offer/offerFooter.tsx
+++ b/components/molecules/offer/offerFooter.tsx
@@ -5,9 +5,10 @@ import { Button } from '../../../@/components/ui/button';
 type FProps = {
     handleAcceptOffer: React.MouseEventHandler<HTMLButtonElement>;
     handleDeclineOffer: React.MouseEventHandler<HTMLButtonElement>;
+    loading: boolean;
 };
 
-export default function OfferFooter({ handleAcceptOffer, handleDeclineOffer }: FProps) {
+export default function OfferFooter({ handleAcceptOffer, handleDeclineOffer, loading }: FProps) {
     return (
         <div className='fixed flex items-center p-2 bg-background gap-2 w-full bottom-0 left-0'>
             <AlertDialog>
@@ -39,8 +40,8 @@ export default function OfferFooter({ handleAcceptOffer, handleDeclineOffer }: F
 
             <AlertDialog>
                 <AlertDialogTrigger asChild>
-                    <Button type='button' className='flex-1'>
-                        Accept
+                    <Button type='button' className='flex-1' disabled={loading}>
+                        {loading ? 'Accepting...' : 'Accept'}
                     </Button>
                 </AlertDialogTrigger>
                 <AlertDialogContent>

--- a/components/organisms/vendor/offer/offerDetails.tsx
+++ b/components/organisms/vendor/offer/offerDetails.tsx
@@ -32,6 +32,7 @@ export default function OfferDetails() {
 
         try {
             await updateDoc(offerRef, {
+                status: 'accepted',
                 accepted: true,
                 updatedAt: serverTimestamp()
             });
@@ -86,6 +87,7 @@ const handleDeclineOffer = () => {
             <OfferFooter
                 handleAcceptOffer={handleAcceptOffer}
                 handleDeclineOffer={handleDeclineOffer}
+                loading={loading}
             />
         </section>
     );

--- a/components/organisms/vendor/offer/offerDetails.tsx
+++ b/components/organisms/vendor/offer/offerDetails.tsx
@@ -2,26 +2,21 @@
 
 'use client'
 
-import { doc, DocumentReference, getDoc } from 'firebase/firestore';
-import { useParams } from 'next/navigation';
+import { doc, DocumentReference, getDoc, serverTimestamp, updateDoc } from 'firebase/firestore';
+import { useParams, useRouter } from 'next/navigation';
 import React from 'react';
+import { useToast } from '../../../../@/components/ui/use-toast';
 import { db } from '../../../../firebaseConfig';
 import OfferContent from '../../../molecules/offer/offerContent';
 import OfferFooter from '../../../molecules/offer/offerFooter';
 import OfferHeader from '../../../molecules/offer/offerHeader';
-import { offers } from './offers';
-
-const handleAcceptOffer = () => {
-    console.log('offer accepted');
-};
-
-const handleDeclineOffer = () => {
-    console.log('offer declined');
-};
 
 export default function OfferDetails() {
     const [offer, setOffer] = React.useState<any>({});
+    const [loading, setLoading] = React.useState(false);
+    const { toast } = useToast();
     const params = useParams();
+    const router = useRouter();
 
     async function getAuthor(uid: DocumentReference) {
         const author = await getDoc(uid);
@@ -30,6 +25,40 @@ export default function OfferDetails() {
             return author;
         }
     }
+        
+    const handleAcceptOffer = async () => {
+        setLoading(true);
+        const offerRef = doc(db, `offers/${params?.offerId}`)
+
+        try {
+            await updateDoc(offerRef, {
+                accepted: true,
+                updatedAt: serverTimestamp()
+            });
+
+            toast({
+                title: 'Offer Accepted',
+                description: 'You have successfully accepted the offer'
+            });
+
+            router.push(`/offers/${params?.offerId}/activity/add-milestones`);
+
+        } catch(error) {
+            console.log('an error occurred');
+            toast({
+                title: 'Offer Accepted',
+                description: 'You have successfully accepted the offer',
+                variant: 'destructive'
+            });
+            
+        } finally {
+            setLoading(false);
+        }
+    };
+
+const handleDeclineOffer = () => {
+    console.log('offer declined');
+};
 
     React.useEffect(() => {
         async function getOffer() {

--- a/components/templates/offers/offerId/activity/add-milestones/add-milestones.tsx
+++ b/components/templates/offers/offerId/activity/add-milestones/add-milestones.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import format from 'date-fns/format';
+import { CalendarIcon } from 'lucide-react';
+import React from 'react';
+import {  useFieldArray, useForm } from 'react-hook-form';
+import { FiPlus } from 'react-icons/fi';
+import { z } from 'zod';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '../../../../../../@/components/ui/accordion';
+import { Button } from '../../../../../../@/components/ui/button';
+import { Calendar } from '../../../../../../@/components/ui/calendar';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '../../../../../../@/components/ui/form';
+import { Input } from '../../../../../../@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '../../../../../../@/components/ui/popover';
+import { Separator } from '../../../../../../@/components/ui/separator';
+import { Textarea } from '../../../../../../@/components/ui/textarea';
+import { cn } from '../../../../../../@/lib/utils';
+
+const milestonesSchema = z.object({
+    title: z.string({ required_error: 'Title is required.' }).max(50, 'Title is too long.'),
+    payment: z.coerce.number(),
+    description: z.string({ required_error: 'Description is required.' }).min(10, 'Description is too short.'),
+    deadline: z.date({ required_error: 'Date is required.' })
+});
+
+export default function AddMilestone() {
+    const { control, handleSubmit } = useForm({
+        resolver: zodResolver(milestonesSchema),
+        mode: 'onChange',
+    });
+    const { append, fields } = useFieldArray({
+        control,
+        name: 'milestones'
+    });
+
+    const handleAddMilestone = (data: any) => {
+        append(data);
+    };
+
+    return (
+        <section className='md:flex gap-6'>
+            <form onSubmit={handleSubmit(handleAddMilestone)}>
+                <section>
+                <section>
+                    <h1 className='font-bold text-2xl max-w-xl'> Almost there. Now create milestones for this project. </h1>
+                    <p className='max-w-md'> 
+                        Milestones are essential for breaking down a larger project into manageable phases, tracking progress and ensuring a smooth collaboration.
+                    </p>
+                </section>
+                <Separator />
+
+                <section className='mt-4 flex-[0.5]'>
+                    <Form {...useForm()}>
+                        <>
+                            <FormField
+                                control={control}
+                                name='title'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel htmlFor='title'> Title </FormLabel>
+                                        <FormControl>
+                                            <Input {...field} placeholder='Title' />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <FormField
+                                control={control}
+                                name='description'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel htmlFor='description'> Description </FormLabel>
+                                        <FormControl>
+                                            <Textarea {...field} placeholder='Write a description' />
+                                        </FormControl>
+                                        <FormDescription>
+                                            Provide an explaination of what this milestone is about and what will be completed.
+                                        </FormDescription>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <FormField
+                                control={control}
+                                name='payment'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel htmlFor='payment'> Payment (%) </FormLabel>
+                                        <FormControl>
+                                            <Input {...field} type='number' placeholder='Payment for this milestone (%)' />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <FormField
+                                control={control}
+                                name='deadline'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel htmlFor='deadline'> Deadline </FormLabel>
+                                            <Popover>
+                                                <PopoverTrigger asChild>
+                                                    <FormControl>
+                                                        <Button
+                                                            variant={"outline"}
+                                                            className={cn(
+                                                                "w-full pl-3 text-left font-normal",
+                                                                !field.value && "text-muted-foreground"
+                                                            )}
+                                                        >
+                                                            {field.value ? (
+                                                                format(field.value, "PPP")
+                                                            ) : (
+                                                                <span> Due date </span>
+                                                            )}
+                                                            <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                                                        </Button>
+                                                    </FormControl>
+                                                </PopoverTrigger>
+                                                <PopoverContent className="w-auto p-0" align="start">
+                                                    <Calendar
+                                                        mode="single"
+                                                        selected={field.value}
+                                                        onSelect={field.onChange}
+                                                        disabled={(date) =>
+                                                            date < new Date() || date < new Date("1900-01-01")
+                                                        }
+                                                        initialFocus
+                                                    />
+                                                </PopoverContent>
+                                            </Popover>
+                                            <FormMessage />
+                                    </FormItem>
+                                    )}
+                                />
+                        </>
+                        <Button className='w-full mt-3 flex items-center gap-2'> <FiPlus /> Add </Button>
+                    </Form>
+                </section>
+                </section>
+            </form>
+
+            <section className='flex-1 mt-6 md:mt-0'>
+                <section className='font-bold'> Milestones ({fields.length}) </section>
+                <section className='h-max border border-md rounded-md bg-gray-50 px-2 py-0'>
+                    {!fields.length 
+                        ? <section className='font-bold flex items-center justify-center h-20'> No milestones added yet. </section>
+                        : fields.map((item: any, index) => (
+                            <section key={item.id} className=''>
+                                <Accordion type='single' collapsible>
+                                    <AccordionItem value={`item-${index}`}>
+                                        <AccordionTrigger> 
+                                            Milestone {index + 1}: {item?.title}
+                                        </AccordionTrigger>
+                                        <AccordionContent>
+                                            <section className='pb-2'>
+                                                <span className='font-bold'> Description: </span> {item?.description}
+                                            </section>
+                                            <section className='flex justify-between items-center'>
+                                                <span> Due: 30 May 2024 </span>
+                                                <span> Payment: {item?.payment}% </span>
+                                            </section>
+                                        </AccordionContent>
+                                    </AccordionItem>
+                                </Accordion>
+                            </section>
+                        ))
+                    }
+                </section>
+            </section>
+        </section>
+    );
+}

--- a/components/templates/offers/offerId/activity/add-milestones/index.tsx
+++ b/components/templates/offers/offerId/activity/add-milestones/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import AddMilestone from './add-milestones';
+
+export default function AddMilestones() {
+    return (
+        <div>
+            <AddMilestone />
+        </div>
+    );
+};

--- a/components/templates/offers/offerId/activity/add-milestones/index.tsx
+++ b/components/templates/offers/offerId/activity/add-milestones/index.tsx
@@ -3,7 +3,7 @@ import AddMilestone from './add-milestones';
 
 export default function AddMilestones() {
     return (
-        <div>
+        <div className='mb-8'>
             <AddMilestone />
         </div>
     );

--- a/components/templates/vendorProfile/createOffer/index.tsx
+++ b/components/templates/vendorProfile/createOffer/index.tsx
@@ -60,7 +60,7 @@ export default function Offer() {
                 to: doc(db, `users/${params?.vendorId}`),
                 comment: null,
                 updatedAt: serverTimestamp(),
-                createdAt: serverTimestamp(),
+                createdAt: new Date(),
             });
             toast({
                 title: 'Success',


### PR DESCRIPTION
In this pull request, I've made a couple of changes in regards to routes and the flow of the program when accepting the offer.

**Problem:**
When adding milestones, they used to be added in `/projects/[projectId]/activity/add-milestones`. Now I've decided to change this behavior and add milestones in `/offers/[offerId]/activity/add-milestones`.

The thought behind adding milestones inside a project was mainly to be able to grab the project ID (in the params) supposedly associated with the offer and make a request to the database for the project details. However, what if the client decides to make an offer without them having an active project yet?

**Proposed Solution:**
My solution to this is that I thought it is safer when using the `/offers/` segment when adding milestones. This will disregard the case if the client has a project or not.